### PR TITLE
Write request signatures directly to memcache

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,26 @@ Status](https://travis-ci.com/m-lab/mlab-ns-rate-limit.svg?branch=master)](https
 Status](https://coveralls.io/repos/m-lab/mlab-ns-rate-limit/badge.svg?branch=master&service=github)](https://coveralls.io/github/m-lab/mlab-ns-rate-limit?branch=master)
 
 # mlab-ns-rate-limit
-Rate limiting support for mlab-ns
 
-TODO: memcache.
+Rate limiting support for mlab-ns.
 
+## Memcache Conventions
+
+mlab-ns-rate-limit writes request signature probabilities directly _to_
+memcache. And, within the same project, mlab-ns is able to read request
+signatures back _from_ memcache.
+
+Because mlab-ns-rate-limit is written in Go, and mlab-ns is written in
+Python, and memcache exposes a generic byte array in Go but a type-aware
+serializer for Python, the two services cannot parse each other's data without
+special handling.
+
+In our case, we use base 10, ASCII encoded integers, which encode fixed point
+decimal values with precision up to 0.0001. For example, to encode a probability
+value of 0.5, mlab-ns-rate-limit will:
+
+* string(0.5 * 10000) -> "5000"
+
+And, mlab-ns would read this value as:
+
+* int("5000") / 10000.0 -> 0.5

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Status](https://coveralls.io/repos/m-lab/mlab-ns-rate-limit/badge.svg?branch=mas
 # mlab-ns-rate-limit
 Rate limiting support for mlab-ns
 
+TODO: memcache.
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ signatures back _from_ memcache.
 Because mlab-ns-rate-limit is written in Go, and mlab-ns is written in
 Python, and memcache exposes a generic byte array in Go but a type-aware
 serializer for Python, the two services cannot parse each other's data without
-special handling.
+adopting a shared convention.
 
 In our case, we use base 10, ASCII encoded integers, which encode fixed point
 decimal values with precision up to 0.0001. For example, to encode a probability

--- a/appengine/rate_table/rate_table.go
+++ b/appengine/rate_table/rate_table.go
@@ -153,6 +153,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"message": "`+err.Error()+`"}`, http.StatusInternalServerError)
 		return
 	}
+	logDebug(ctx, "Set %d endpoint keys in memcache", len(keys))
 
 	client, err := datastore.NewClient(ctx, projectID)
 	if err != nil {

--- a/appengine/rate_table/rate_table.go
+++ b/appengine/rate_table/rate_table.go
@@ -39,7 +39,6 @@ func init() {
 	// Always prepend the filename and line number.
 	http.HandleFunc("/", defaultHandler)
 	http.HandleFunc("/benchmark", benchmark)
-	http.HandleFunc("/memcache", memcacheHandler)
 	http.HandleFunc("/status", Status)
 	http.HandleFunc("/update_request_signatures", Update)
 }
@@ -197,29 +196,6 @@ func defaultHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	fmt.Fprintf(w, defaultMessage)
-}
-
-func memcacheHandler(w http.ResponseWriter, r *http.Request) {
-	c := appengine.NewContext(r)
-
-	ctx, err := appengine.Namespace(c, "soltesz_memcache_test")
-	if err != nil {
-		logCritical(ctx, "Namespace: %v", err)
-	}
-
-	if err := memcache.Set(ctx, &memcache.Item{Key: "rl-string", Value: []byte("hello"), Expiration: time.Hour}); err != nil {
-		logCritical(ctx, "memcache.Set: %v", err)
-		return
-	}
-	if err := memcache.Set(ctx, &memcache.Item{Key: "rl-int", Value: []byte("134"), Expiration: time.Hour}); err != nil {
-		logCritical(ctx, "memcache.Set: %v", err)
-		return
-	}
-	if err := memcache.Set(ctx, &memcache.Item{Key: "rl-float", Value: []byte("0.134"), Expiration: time.Hour}); err != nil {
-		logCritical(ctx, "memcache.Set: %v", err)
-		return
-	}
-	fmt.Fprintf(w, "ok")
 }
 
 func benchmark(w http.ResponseWriter, r *http.Request) {

--- a/appengine/rate_table/rate_table.go
+++ b/appengine/rate_table/rate_table.go
@@ -41,7 +41,7 @@ func init() {
 	http.HandleFunc("/benchmark", benchmark)
 	http.HandleFunc("/memcache", memcacheHandler)
 	http.HandleFunc("/status", Status)
-	http.HandleFunc("/update", Update)
+	http.HandleFunc("/update_request_signatures", Update)
 }
 
 // Status writes an instance summary into the response.

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -272,73 +272,6 @@ LIMIT 20000`
 // sixHourQuery looks for clients that run every six hours and issue requests
 // to both /ndt and /neubot.
 var sixHourQuery = `
-WITH
-  clientsInSixHourPeriods AS (
-    SELECT
-      protoPayload.ip as ip,
-      protoPayload.resource as resource,
-      COUNT(*) AS requestsPerDay,
-      CASE
-        WHEN protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 19 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 81 MINUTE) THEN 1
-        WHEN protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 379 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 441 MINUTE) THEN 2
-        WHEN protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 739 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 801 MINUTE) THEN 4
-        WHEN protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 1099 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 1161 MINUTE) THEN 8
-        ELSE 0
-      END AS period
-    FROM
-  ` + "`mlab-ns.exports.appengine_googleapis_com_request_log_*`" + `
-    WHERE
-         (_table_suffix = FORMAT_DATE("%Y%m%d", CURRENT_DATE())
-      OR  _table_suffix = FORMAT_DATE("%Y%m%d", DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY))
-      OR  _table_suffix = FORMAT_DATE("%Y%m%d", DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))
-      AND protoPayload.starttime > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2 DAY))
-      AND (protoPayload.resource = '/neubot' OR protoPayload.resource = '/ndt')
-      AND protoPayload.userAgent is NULL
-    GROUP BY
-      -- Also group by 'period' to guarantee that we only have one representative
-      -- request from each ip and resource.
-      ip, resource, period
-  ),
-  clientsOutsideSixHourPeriods AS (
-    SELECT
-      protoPayload.ip as ip
-    FROM
-  ` + "`mlab-ns.exports.appengine_googleapis_com_request_log_*`" + `
-    WHERE
-         (_table_suffix = FORMAT_DATE("%Y%m%d", CURRENT_DATE())
-      OR  _table_suffix = FORMAT_DATE("%Y%m%d", DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY))
-      OR  _table_suffix = FORMAT_DATE("%Y%m%d", DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))
-      AND protoPayload.starttime > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2 DAY))
-      AND (protoPayload.resource = '/neubot' OR protoPayload.resource = '/ndt')
-      AND protoPayload.userAgent is NULL
-      AND (
-          protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 0 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 19 MINUTE) OR
-          protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 81 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 379 MINUTE) OR
-          protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 441 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 739 MINUTE) OR
-          protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 801 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 1099 MINUTE) OR
-          protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 1161 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 1440 MINUTE)
-      )
-    GROUP BY
-      ip
-  ),
-  nsRequestsInSixHourPeriods AS (
-    SELECT
-      ip, resource, SUM(period) as total
-    FROM
-      clientsInSixHourPeriods
-    GROUP BY
-      ip, resource
-    HAVING
-      -- Guarantee that each client runs in each period by totaling the 'period'
-      -- values. If all periods are represented, then the sum(1 + 2 + 4 + 8) = 15.
-      total = 15
-  ),
-  uniqueIPsInSixHourPeriods AS (
-    (SELECT ip FROM nsRequestsInSixHourPeriods WHERE resource = "/neubot" AND ip NOT IN ( SELECT ip FROM clientsOutsideSixHourPeriods )
-     intersect DISTINCT
-     SELECT ip FROM nsRequestsInSixHourPeriods WHERE resource = "/ndt" AND ip NOT IN ( SELECT ip FROM clientsOutsideSixHourPeriods ))
-  )
-
 SELECT
     protoPayload.ip AS RequesterIP,
     protoPayload.resource as resource,
@@ -353,7 +286,7 @@ WHERE
   AND protoPayload.starttime > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2 DAY))
   AND (protoPayload.resource = '/neubot' OR protoPayload.resource = '/ndt')
   AND protoPayload.userAgent IS NULL
-  AND protoPayload.ip IN ( SELECT ip FROM uniqueIPsInSixHourPeriods )
+  AND protoPayload.ip IN ( SELECT ip FROM ` + "`mlab-ns.library.unique_ips_in_six_hour_periods`" + ` )
 GROUP BY
   RequesterIP, protoPayload.resource, protoPayload.userAgent
 ORDER BY

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -225,7 +225,7 @@ func SetMulti(c context.Context, keys []*datastore.Key, endpoints []Stats) error
 			end = len(keys)
 		}
 
-		var items []*memcache.Item
+		items := make([]*memcache.Item, 0, 500)
 		for i := range keys[start:end] {
 			items = append(items, &memcache.Item{
 				Key:        keys[start+i].Name,
@@ -240,7 +240,7 @@ func SetMulti(c context.Context, keys []*datastore.Key, endpoints []Stats) error
 
 		// Guarantee that we stay under memcache "dedicated" SLO of 10k ops/sec/GB.
 		//   1_sec / (10000_ops / 500_ops/batch ) == 0.050_sec/batch.
-		time.Sleep(time.Millisecond * 50)
+		time.Sleep(50 * time.Millisecond)
 	}
 	return memcache.Set(ctx, &memcache.Item{Key: "sanity_check", Value: []byte("success"), Expiration: time.Hour})
 }

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -213,7 +213,7 @@ func PutMulti(ctx context.Context, client *datastore.Client, keys []*datastore.K
 // encoded integer. Readers should parse the value as an int, then divide by 10000
 // to recover the original probability.
 func SetMulti(c context.Context, keys []*datastore.Key, endpoints []Stats) error {
-	ctx, err := appengine.Namespace(c, "soltesz_memcache_test")
+	ctx, err := appengine.Namespace(c, "memcache_requests")
 	if err != nil {
 		return err
 	}
@@ -238,9 +238,7 @@ func SetMulti(c context.Context, keys []*datastore.Key, endpoints []Stats) error
 			return err
 		}
 	}
-	log.Println("Put", len(keys), "entities")
-	return memcache.Set(ctx, &memcache.Item{Key: "soltesz-finish", Value: []byte("hello"), Expiration: time.Hour})
-	// return nil
+	return memcache.Set(ctx, &memcache.Item{Key: "sanity_check", Value: []byte("success"), Expiration: time.Hour})
 }
 
 // simpleQuery queries the stackdriver request log table, and extracts the count

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -15,6 +15,7 @@ import (
 	"cloud.google.com/go/datastore"
 	"github.com/m-lab/go/bqext"
 	"github.com/m-lab/mlab-ns-rate-limit/endpoint"
+	"google.golang.org/appengine/aetest"
 )
 
 func init() {
@@ -116,7 +117,12 @@ func TestCreateTestEntries(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	ctx := context.Background()
+	ctx, done, err := aetest.NewContext()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer done()
+
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -128,6 +134,12 @@ func TestCreateTestEntries(t *testing.T) {
 
 	// Save all the keys
 	err = endpoint.PutMulti(ctx, client, keys, endpoints)
+	if err != nil {
+		log.Fatalf("Failed: %v", err)
+	}
+
+	// Save all the keys
+	err = endpoint.SetMulti(ctx, keys, endpoints)
 	if err != nil {
 		log.Fatalf("Failed: %v", err)
 	}

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -39,7 +39,7 @@ func TestDeleteAllKeys(t *testing.T) {
 
 	client, err := getClient()
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	// Just verify that the call completes successfully.
@@ -84,7 +84,7 @@ func TestLiveBQQuery(t *testing.T) {
 
 	keys, _, err := endpoint.MakeKeysAndStats(rows)
 	if err != nil {
-		log.Fatalf("Failed: %v", err)
+		t.Fatalf("Failed: %v", err)
 	}
 	log.Println(len(keys), "rows over threshold")
 	// Test is meaningless if there are no interesting clients
@@ -104,7 +104,7 @@ func TestCreateTestEntries(t *testing.T) {
 
 	keys, endpoints, err := endpoint.MakeKeysAndStats(rows)
 	if err != nil {
-		log.Fatalf("Failed: %v", err)
+		t.Fatalf("Failed: %v", err)
 	}
 	log.Println(len(keys), "rows over threshold")
 	// Test is meaningless if there are no interesting clients
@@ -114,7 +114,7 @@ func TestCreateTestEntries(t *testing.T) {
 
 	client, err := getClient()
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	ctx, done, err := aetest.NewContext()
@@ -129,19 +129,19 @@ func TestCreateTestEntries(t *testing.T) {
 	// This is OK, because we are using client ProjectID mlab-testing.
 	_, err = endpoint.DeleteAllKeys(ctx, client, "endpoint_stats", "Requests")
 	if err != nil {
-		log.Fatal(len(keys), err)
+		t.Fatal(len(keys), err)
 	}
 
 	// Save all the keys
 	err = endpoint.PutMulti(ctx, client, keys, endpoints)
 	if err != nil {
-		log.Fatalf("Failed: %v", err)
+		t.Fatalf("Failed: %v", err)
 	}
 
 	// Save all the keys
 	err = endpoint.SetMulti(ctx, keys, endpoints)
 	if err != nil {
-		log.Fatalf("Failed: %v", err)
+		t.Fatalf("Failed: %v", err)
 	}
 
 	// Even the datastore emulator takes a little while to become consistent, so
@@ -151,7 +151,7 @@ func TestCreateTestEntries(t *testing.T) {
 		time.Sleep(delay)
 		found, err = endpoint.GetAllKeys(ctx, client, "endpoint_stats", "Requests")
 		if err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 		if len(found) == len(keys) {
 			return


### PR DESCRIPTION
This change is a companion to https://github.com/m-lab/mlab-ns/pull/181

mlab-ns-rate-limit now writes directly to memcache to obviate the need for mlab-ns to ever read from Datastore (except as a periodic sanity check).

mlab-ns-rate-limit still writes all client signatures to Datastore for visibility by a human operator and automatic sanity checking by mlab-ns.

As well, this change updates the six hour query to rely on a new library view: `mlab-ns.library.unique_ips_in_six_hour_periods`

Note: the travis build status is broken atm for this repo. After making it public the old private travis configuration is still running, successfully, here https://travis-ci.com/m-lab/mlab-ns-rate-limit -- but the new one is failing which is what Github status uses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns-rate-limit/14)
<!-- Reviewable:end -->
