### PR TITLE
Enable rate-limit using a threshold of 40 requests per day.

### DIFF
--- a/appengine/rate_table/rate_table.go
+++ b/appengine/rate_table/rate_table.go
@@ -24,6 +24,11 @@ import (
 	"google.golang.org/appengine/memcache"
 )
 
+// threshold defines the maximum requests per day for a client before being rate
+// limited. Start with a conservative threshold. Ideally, we want a lower limit
+// for batch jobs than interactive users.
+const threshold = 40
+
 // 1.  Datastore stuff
 // 2.  Bigquery stuff
 // 3.  Bloom filter stuff
@@ -88,9 +93,6 @@ func NewDataset(ctx context.Context, project, dataset string, clientOpts ...opti
 func Update(w http.ResponseWriter, r *http.Request) {
 	// TODO - load threshold from flags or env-vars (see Peter's code?)
 	// TODO - move env var loading to init() ?
-	// Start with a conservative threshold. Ideally, we want a lower limit for
-	// batch jobs than interactive users.
-	threshold := 40                             // requests per day
 	projectID, ok := os.LookupEnv("PROJECT_ID") // Datastore output project
 	if ok != true {
 		// metrics.FailCount.WithLabelValues("environ").Inc()

--- a/appengine/rate_table/rate_table.go
+++ b/appengine/rate_table/rate_table.go
@@ -90,7 +90,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	// TODO - move env var loading to init() ?
 	// Start with a conservative threshold. Ideally, we want a lower limit for
 	// batch jobs than interactive users.
-	threshold := 20                             // requests per day
+	threshold := 40                             // requests per day
 	projectID, ok := os.LookupEnv("PROJECT_ID") // Datastore output project
 	if ok != true {
 		// metrics.FailCount.WithLabelValues("environ").Inc()

--- a/appengine/rate_table/rate_table.go
+++ b/appengine/rate_table/rate_table.go
@@ -88,7 +88,9 @@ func NewDataset(ctx context.Context, project, dataset string, clientOpts ...opti
 func Update(w http.ResponseWriter, r *http.Request) {
 	// TODO - load threshold from flags or env-vars (see Peter's code?)
 	// TODO - move env var loading to init() ?
-	threshold := 12                             // requests per day
+	// Start with a conservative threshold. Ideally, we want a lower limit for
+	// batch jobs than interactive users.
+	threshold := 20                             // requests per day
 	projectID, ok := os.LookupEnv("PROJECT_ID") // Datastore output project
 	if ok != true {
 		// metrics.FailCount.WithLabelValues("environ").Inc()
@@ -130,7 +132,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	keys, endpoints, err := endpoint.MakeKeysAndStats(rows)
+	keys, endpoints, err := endpoint.MakeKeysAndStats(rows, threshold)
 	if err != nil {
 		logWarning(ctx, "MakeKeysAndStats: %v", err)
 		// metrics.FailCount.WithLabelValues("make").Inc()

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -259,7 +259,8 @@ FROM (
   WHERE
     (_table_suffix = FORMAT_DATE("%Y%m%d", CURRENT_DATE())
     OR _table_suffix = FORMAT_DATE("%Y%m%d", DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)))
-    AND protoPayload.starttime > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
+		AND protoPayload.starttime > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
+		AND (REGEXP_CONTAINS(protoPayload.resource, '/neubot') OR REGEXP_CONTAINS(protoPayload.resource, '/ndt'))
   GROUP BY
     RequesterIP, userAgent, resource )
 WHERE

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -82,7 +82,7 @@ func TestLiveBQQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	keys, _, err := endpoint.MakeKeysAndStats(rows)
+	keys, _, err := endpoint.MakeKeysAndStats(rows, 20)
 	if err != nil {
 		t.Fatalf("Failed: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestCreateTestEntries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	keys, endpoints, err := endpoint.MakeKeysAndStats(rows)
+	keys, endpoints, err := endpoint.MakeKeysAndStats(rows, 20)
 	if err != nil {
 		t.Fatalf("Failed: %v", err)
 	}


### PR DESCRIPTION
This change restores the rate limit logic to using the original `simpleQuery` looking for clients that request mlab-ns more than THREADHOLD times a day. This change sets that threshold to 40 to attempt to be conservative at first.

Clients that exceed this rate are assigned a probability proportionate to `threshold / requests_per_day`. The higher the probability the more likely they will be directed to the production platform. The lower the probability (and higher daily request rate) the more likely the client will see an offload VM or a 'no capacity' response from mlab-ns (empty result).

Currently there are less than 1000 clients exceeding this threshold.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns-rate-limit/15)
<!-- Reviewable:end -->
