### PR TITLE
Truncate memcache keys at 250 bytes

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -60,7 +60,13 @@ func StatsFromMap(row map[string]bigquery.Value, threshold int) (string, Stats) 
 	if ip == nil {
 		ip = ""
 	}
-	key := fmt.Sprintf("%s#%s#%s", userAgent, resource, ip)
+	key := fmt.Sprintf("%s#%s#%s", ip, userAgent, resource)
+
+	// Memcache keys cannot be longer than 250 bytes, but this string could be,
+	// so we truncate it after the first 250 bytes.
+	if len(key) > 250 {
+		key = key[:250]
+	}
 	return key, stats
 }
 


### PR DESCRIPTION
Memcache keys cannot be longer than 250 bytes, thus we need to make sure the key generated by concatenating ip+userAgent+resource does not exceed that. This is likely the cause of an error we are seeing in production where some entities are not being written on memcache and are making the bulk operation fail - and the service return a 500.

Also, the order in which the elements are concatenated has been changed so that
the most identifying information (IP and User Agent) comes first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns-rate-limit/16)
<!-- Reviewable:end -->
