### PR TITLE
migrate to go/cloud/bqx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- '1.9'
+- '1.11'
 
 # Unconditionally place the repo at GOPATH/src/${go_import_path} to support
 # forks.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- '1.11'
+- '1.13'
 
 # Unconditionally place the repo at GOPATH/src/${go_import_path} to support
 # forks.

--- a/appengine/rate_table/rate_table.go
+++ b/appengine/rate_table/rate_table.go
@@ -16,7 +16,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/datastore"
-	"github.com/m-lab/go/bqext"
+	"github.com/m-lab/go/cloud/bqx"
 	"github.com/m-lab/mlab-ns-rate-limit/endpoint"
 	"google.golang.org/api/option"
 	"google.golang.org/appengine"
@@ -75,16 +75,16 @@ func Status(w http.ResponseWriter, r *http.Request) {
 // Additional bigquery ClientOptions may be optionally passed as final
 // clientOpts argument.  This is useful for testing credentials.
 // TODO - update go/bqext version to accept a context.
-func NewDataset(ctx context.Context, project, dataset string, clientOpts ...option.ClientOption) (bqext.Dataset, error) {
+func NewDataset(ctx context.Context, project, dataset string, clientOpts ...option.ClientOption) (bqx.Dataset, error) {
 	var bqClient *bigquery.Client
 	var err error
 	bqClient, err = bigquery.NewClient(ctx, project, clientOpts...)
 
 	if err != nil {
-		return bqext.Dataset{}, err
+		return bqx.Dataset{}, err
 	}
 
-	return bqext.Dataset{bqClient.Dataset(dataset), bqClient}, nil
+	return bqx.Dataset{bqClient.Dataset(dataset), bqClient}, nil
 }
 
 // Update pulls new data from BigQuery, and pushes updated key/value pairs

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -16,7 +16,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/datastore"
-	"github.com/m-lab/go/bqext"
+	"github.com/m-lab/go/cloud/bqx"
 	"google.golang.org/api/iterator"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/memcache"
@@ -132,7 +132,7 @@ func MakeKeysAndStats(rows []map[string]bigquery.Value, threshold int) ([]*datas
 // FetchEndpointStats executes simpleQuery, and returns a slice of rows containing
 // endpoint signatures and request counts.
 // TODO - move the body (excluding simpleQuery) into go/bqext
-func FetchEndpointStats(ctx context.Context, dsExt *bqext.Dataset, threshold int) ([]map[string]bigquery.Value, error) {
+func FetchEndpointStats(ctx context.Context, dsExt *bqx.Dataset, threshold int) ([]map[string]bigquery.Value, error) {
 	qString := strings.Replace(simpleQuery, "${THRESHOLD}", fmt.Sprint(threshold), 1)
 	qString = strings.Replace(qString, "${DATE}", fmt.Sprint(threshold), 1)
 

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -13,7 +13,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/datastore"
-	"github.com/m-lab/go/bqext"
+	"github.com/m-lab/go/cloud/bqx"
 	"github.com/m-lab/mlab-ns-rate-limit/endpoint"
 	"google.golang.org/appengine/aetest"
 )
@@ -69,7 +69,7 @@ func TestLiveBQQuery(t *testing.T) {
 	}
 
 	// Using the real mlab-ns table!
-	dsExt, err := bqext.NewDataset("mlab-ns", "exports")
+	dsExt, err := bqx.NewDataset("mlab-ns", "exports")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This removes dependencies on deprecated packages (in obsolete paths).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns-rate-limit/18)
<!-- Reviewable:end -->
