### PR TITLE
Update to go113 runtime

### DIFF
--- a/appengine/rate_table/app.yaml
+++ b/appengine/rate_table/app.yaml
@@ -1,10 +1,9 @@
-runtime: go
-api_version: go1
+runtime: go113
 service: rate-limiter
 
 handlers:
 - url: /.*
-  script: _go_app
+  script: auto
 
 env_variables:
   # These should be substituted in the travis deployment script.

--- a/appengine/rate_table/rate_table.go
+++ b/appengine/rate_table/rate_table.go
@@ -2,7 +2,7 @@
 // entries to control mlab-ns rate limiting.
 // TODO - add more metrics?
 // TODO - update travis submodule after deploy_app changes are committed.
-package rate_table
+package main
 
 import (
 	"context"
@@ -40,12 +40,13 @@ const threshold = 40
 //  c. Will create a bloom filter and also store it in datastore.
 //  d. Will not handle memcache entries, as python uses pickling, and go uses binary, json or gob.
 
-func init() {
+func main() {
 	// Always prepend the filename and line number.
 	http.HandleFunc("/", defaultHandler)
 	http.HandleFunc("/benchmark", benchmark)
 	http.HandleFunc("/status", Status)
 	http.HandleFunc("/update_request_signatures", Update)
+	appengine.Main()
 }
 
 // Status writes an instance summary into the response.

--- a/appengine/rate_table/rate_table_test.go
+++ b/appengine/rate_table/rate_table_test.go
@@ -1,4 +1,4 @@
-package rate_table_test
+package main_test
 
 import (
 	"context"


### PR DESCRIPTION
This change updates the App Engine Standard Env runtime to go113. The "go" runtime is now deprecated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns-rate-limit/19)
<!-- Reviewable:end -->
