### PR TITLE
Temporarily exclude locate/v2 proxy requests

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -289,6 +289,11 @@ FROM (
     OR _table_suffix = FORMAT_DATE("%Y%m%d", DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)))
 		AND protoPayload.starttime > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
 		AND (REGEXP_CONTAINS(protoPayload.resource, '/neubot') OR REGEXP_CONTAINS(protoPayload.resource, '/ndt'))
+    AND NOT (
+        // NOTE: temporarily exclude proxy requests from the locate/v2 service.
+        // TODO: include locate/v2 requests.
+        REGEXP_CONTAINS(protoPayload.resource, '/ndt.*lat=.*lon=.*policy=geo_options')
+    )
   GROUP BY
     RequesterIP, userAgent, resource )
 WHERE
@@ -297,4 +302,5 @@ GROUP BY
   RequesterIP, userAgent, resource, RequestsPerDay
 ORDER BY
   RequestsPerDay DESC
-LIMIT 20000`
+LIMIT 20000
+`


### PR DESCRIPTION
During initial client development of the locate/v2 API, several users are reporting premature rate limiting.

This change exempts the locate/v2 proxied requests from the rate limit calculation.

This is temporary.

The consequence is that users of the locate/v2 API will not be rate limited until that is handled natively in the locate service.

Addresses https://github.com/m-lab/locate/issues/17
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns-rate-limit/20)
<!-- Reviewable:end -->
