### PR TITLE
Change query comment character & Revert go runtime for memcache access

### DIFF
--- a/appengine/rate_table/app.yaml
+++ b/appengine/rate_table/app.yaml
@@ -1,4 +1,4 @@
-runtime: go113
+runtime: go111
 service: rate-limiter
 
 handlers:

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -290,8 +290,8 @@ FROM (
 		AND protoPayload.starttime > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
 		AND (REGEXP_CONTAINS(protoPayload.resource, '/neubot') OR REGEXP_CONTAINS(protoPayload.resource, '/ndt'))
     AND NOT (
-        // NOTE: temporarily exclude proxy requests from the locate/v2 service.
-        // TODO: include locate/v2 requests.
+        -- NOTE: temporarily exclude proxy requests from the locate/v2 service.
+        -- TODO: include locate/v2 requests.
         REGEXP_CONTAINS(protoPayload.resource, '/ndt.*lat=.*lon=.*policy=geo_options')
     )
   GROUP BY


### PR DESCRIPTION
For reasons unknown, comment characters that work in the GCP console do not work when provided programatically.

```
{"message": "Fetch: googleapi: Error 400: Syntax error: Unexpected "/" at [15:9], invalidQuery"}
```

This change updates the comment character to prevent that error.

As well, the runtimes greater than go111 do not support memcache. Instead, memstore is the preferred RAM store solution. But, we require memcache to interoperate with mlab-ns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns-rate-limit/21)
<!-- Reviewable:end -->
